### PR TITLE
Fix for Bug #4...

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,13 @@
 
 module.exports = normalize
 
-var arcToCurve = require('svg-arc-to-cubic-bezier')
+var arcToCurve = require('svg-arc-to-cubic-bezier');
+// Need to check to see if this is truly the function that we need
+if (typeof arcToCurve !== 'function'){
+  if (typeof arcToCurve === 'object' && arcToCurve.default && typeof arcToCurve.default === 'function'){
+    arcToCurve = arcToCurve.default;
+  }
+}
 
 function normalize(path){
   // init state


### PR DESCRIPTION
Looks like the 'svg-arc-to-cubic-bezier' module is using ES6Modules so that we can mix within a build that doesn't use the babel compiler.  This code will allow people like me to build without that need.  Using the ES6 conventions